### PR TITLE
Reports should have response Type ResourceList

### DIFF
--- a/src/FireText/Api/Request/DeliveryReport.php
+++ b/src/FireText/Api/Request/DeliveryReport.php
@@ -5,7 +5,7 @@ use FireText\Api\Credentials\CredentialsInterface as Credentials;
 
 class DeliveryReport extends AbstractRequest
 {
-    protected $responseType = 'FireText\Api\Response\Resource';
+    protected $responseType = 'FireText\Api\Response\ResourceList';
     
     protected $responseResourceType = 'FireText\Api\Resource\DeliveryReport';
 


### PR DESCRIPTION
A messageId can have multiple recipients so DeliveryReport needs to be of type ResourceList not Resource to allow for an array of delivery report responses.
